### PR TITLE
Update codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,5 +17,5 @@ coverage:
 
 
 comment:
-  layout: "header, diff, changes, suggestions"
+  layout: "header, diff, changes, uncovered"
   behavior: default


### PR DESCRIPTION
We changed `suggestions` to `uncovered`. I'm curious, where did you see the `suggestions` value at?

Thank you!

PS to validate `curl --data-binary @codecov.yml https://codecov.io/validate`
